### PR TITLE
Update index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -166,7 +166,6 @@ async function gatherExcludes({ baseRef, exec }) {
 		`origin/${baseRef}`,
 		'HEAD',
 		'--name-only',
-		'--no-renames',
 	]);
 	const files = o1.stdout.split(/\r?\n/).filter((n) => n.length > 0);
 
@@ -213,7 +212,6 @@ async function getSize({ baseRef, exec, excludes, ignores, ignoreDeletedLines })
 		'diff',
 		`origin/${baseRef}`,
 		'HEAD',
-		'--no-renames',
 		'--numstat',
 		'--ignore-space-change',
 		'--',


### PR DESCRIPTION
This pull request makes minor adjustments to the `index.js` file by removing the `--no-renames` option from two Git commands. These changes simplify the handling of renamed files in the affected functions.

### Changes to Git commands:

* [`gatherExcludes`](diffhunk://#diff-e727e4bdf3657fd1d798edcd6b099d6e092f8573cba266154583a746bba0f346L169): Removed the `--no-renames` option from the `git diff` command, which now allows renamed files to be included in the output.
* [`getSize`](diffhunk://#diff-e727e4bdf3657fd1d798edcd6b099d6e092f8573cba266154583a746bba0f346L216): Removed the `--no-renames` option from the `git diff` command, ensuring renamed files are considered when calculating file size changes.